### PR TITLE
Client event just before and after transition

### DIFF
--- a/cloading.lua
+++ b/cloading.lua
@@ -110,7 +110,7 @@ Citizen.CreateThread(function()
             break
         end
     end
-    
+    TriggerEvent("JoinTransition:FinishLoading");  
     -- Reset the draw origin, just in case (allowing HUD elements to re-appear correctly)
     ClearDrawOrigin()
 end)

--- a/cloading.lua
+++ b/cloading.lua
@@ -85,6 +85,9 @@ Citizen.CreateThread(function()
     
     -- Re-enable the sound in case it was muted.
     ToggleSound(false)
+        
+    -- Fires a Client event that other resources can use just before starting to transition
+    TriggerEvent("JoinTransition:Loading");     
     
     while true do
         ClearScreen()


### PR DESCRIPTION
Basically just fires an event that can be used in any other resource while in the clouds (Example: setting player location, or triggering login to database) 